### PR TITLE
Fix test for secret, upgrade onchainkit to v0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@coinbase/onchainkit": "^0.4.5"
+        "@coinbase/onchainkit": "^0.5.4"
       },
       "devDependencies": {
         "@phala/fn": "~0.2.14",
@@ -26,12 +26,13 @@
       "license": "MIT"
     },
     "node_modules/@coinbase/onchainkit": {
-      "version": "0.4.5",
-      "license": "MIT",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@coinbase/onchainkit/-/onchainkit-0.5.4.tgz",
+      "integrity": "sha512-fF8cwAmamM/az1TBbaZVPcAdrCdZ3db2FPIdRoWPrcLIU2Xmdw7EM2uaiwzzbfoGDkkgEt4nUefAH5P4mFrORw==",
       "peerDependencies": {
         "react": "^18",
         "react-dom": "^18",
-        "viem": "^2.5.0"
+        "viem": "^2.7.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "^0.4.5"
+    "@coinbase/onchainkit": "^0.5.4"
   }
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -29,18 +29,18 @@ async function test() {
         method: 'GET',
         path: '/ipfs/QmVHbLYhhYA5z6yKpQr4JWr3D54EhbSsh7e7BFAAyrkkMf',
         queries: {},
-        secrets: {},
+        secret: {},
         headers: {},
     })
     console.log('GET RESULT:', JSON.parse(getResult))
-    
+
     const postResult = await execute({
         method: 'POST',
         path: '/ipfs/QmVHbLYhhYA5z6yKpQr4JWr3D54EhbSsh7e7BFAAyrkkMf',
         queries: {
             page: ['1'],
         },
-        secrets: {},
+        secret: {},
         headers: {},
         body: JSON.stringify(sampleInput)
     })


### PR DESCRIPTION
I upgraded onchain-kit to v0.5.4. The v0.6.x version uses vite & no longer has the compile JS code in `@coinbase/onchainkit/dist/` which breaks out template. This version has the latest Frame specs, so this is good for now.